### PR TITLE
editページのメインimgサイズを変更

### DIFF
--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -431,7 +431,8 @@ body {
       cursor: pointer;
     }
     img {
-      height: 500px;
+      height: 100%;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
cover-image-uploadに設定されているサイズの100%に縦横が広がるよう変更